### PR TITLE
I've made a couple of changes to the front-end tests to address an is…

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,6 +1,8 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+vi.mock('@/services/signalRService', () => import('@/services/__mocks__/signalRService'));
+
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {
   writable: true,

--- a/src/services/__mocks__/signalRService.ts
+++ b/src/services/__mocks__/signalRService.ts
@@ -1,0 +1,49 @@
+import { vi } from 'vitest';
+
+const createMockConnection = () => ({
+  start: vi.fn().mockResolvedValue(null),
+  stop: vi.fn().mockResolvedValue(null),
+  on: vi.fn(),
+  off: vi.fn(),
+  invoke: vi.fn().mockResolvedValue(null),
+  onclose: vi.fn(),
+  onreconnecting: vi.fn(),
+  onreconnected: vi.fn(),
+  state: 'Disconnected',
+  connectionId: 'mock-connection-id',
+});
+
+export const signalRService = {
+  initializeConnection: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  syncTimer: vi.fn(),
+  notifyTaskUpdate: vi.fn(),
+  notifyProgressUpdate: vi.fn(),
+  joinCoworkingSession: vi.fn(),
+  leaveCoworkingSession: vi.fn(),
+  joinPersonalChannel: vi.fn(),
+  onTimerSync: vi.fn(() => () => {}),
+  onTaskUpdate: vi.fn(() => () => {}),
+  onProgressUpdate: vi.fn(() => () => {}),
+  isConnected: vi.fn(() => false),
+  getConnectionState: vi.fn(() => 'Disconnected'),
+  getConnectionInfo: vi.fn(() => ({
+    state: 'Disconnected',
+    connectionId: null,
+    reconnectAttempts: 0,
+    isConnecting: false,
+  })),
+  connection: createMockConnection(),
+};
+
+export const useSignalR = () => ({
+  service: signalRService,
+  isConnected: signalRService.isConnected(),
+  connectionState: signalRService.getConnectionState(),
+  onTimerSync: signalRService.onTimerSync,
+  onTaskUpdate: signalRService.onTaskUpdate,
+  onProgressUpdate: signalRService.onProgressUpdate,
+});
+
+export default signalRService;


### PR DESCRIPTION
…sue with the SignalR service. I've created a mock for the service, which will prevent it from trying to connect during testing. I've also configured Vitest to use this mock, which should resolve the console errors you were seeing and prevent potential CI failures.